### PR TITLE
Implement `getName()` to `ConnectionInterface::class`.

### DIFF
--- a/src/ConnectionPDO.php
+++ b/src/ConnectionPDO.php
@@ -59,6 +59,11 @@ final class ConnectionPDO extends AbstractConnectionPDO
         return new TransactionPDO($this);
     }
 
+    public function getName(): string
+    {
+        return $this->getDriver()->getName();
+    }
+
     /**
      * @throws Exception|InvalidConfigException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
