### PR TITLE
Fix 9: Move `truncateTable()` to `DDLQueryBuilder::class`.

### DIFF
--- a/src/DDLQueryBuilder.php
+++ b/src/DDLQueryBuilder.php
@@ -193,4 +193,9 @@ final class DDLQueryBuilder extends AbstractDDLQueryBuilder
             . ' RENAME TO '
             . $this->quoter->quoteTableName($newName);
     }
+
+    public function truncateTable(string $table): string
+    {
+        return 'DELETE FROM ' . $this->quoter->quoteTableName($table);
+    }
 }

--- a/src/DMLQueryBuilder.php
+++ b/src/DMLQueryBuilder.php
@@ -63,11 +63,6 @@ final class DMLQueryBuilder extends AbstractDMLQueryBuilder
         return 'UPDATE sqlite_sequence SET seq=' . $value . " WHERE name='" . $table->getName() . "'";
     }
 
-    public function truncateTable(string $table): string
-    {
-        return 'DELETE FROM ' . $this->quoter->quoteTableName($table);
-    }
-
     /**
      * @throws Exception|InvalidArgumentException|InvalidConfigException|JsonException|NotSupportedException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
