### PR TITLE
Fix phpdoc `AbstractTokenizer`, `LikeConditionBuilder`, rename `BaseTokenizer` to `AbstractTokenizer`.

### DIFF
--- a/src/AbstractTokenizer.php
+++ b/src/AbstractTokenizer.php
@@ -19,7 +19,7 @@ use function usort;
 /**
  * Splits an SQL query into individual SQL tokens.
  *
- * It can be used to obtain an addition information from an SQL code.
+ * It can be used to obtain addition information from an SQL code.
  *
  * Usage example:
  *
@@ -31,7 +31,7 @@ use function usort;
  *
  * Tokens are instances of {@see SqlToken}.
  */
-abstract class BaseTokenizer
+abstract class AbstractTokenizer
 {
     /**
      * @var int SQL code string length.
@@ -52,7 +52,7 @@ abstract class BaseTokenizer
     private SplStack $tokenStack;
 
     /**
-     * @var array|SqlToken active token. It's usually a top of the token stack.
+     * @var array|SqlToken Active token. It's usually a top of the token stack.
      *
      * @psalm-var SqlToken|SqlToken[]
      * @psalm-suppress PropertyNotSetInConstructor
@@ -136,13 +136,13 @@ abstract class BaseTokenizer
     }
 
     /**
-     * Returns whether there's a whitespace at the current offset.
+     * Returns whether there's a space or blank at the current offset.
      *
      * If this method returns `true`, it has to set the `$length` parameter to the length of the matched string.
      *
      * @param int $length Length of the matched string.
      *
-     * @return bool Whether there's a whitespace at the current offset.
+     * @return bool Whether there's a space or blank at the current offset.
      */
     abstract protected function isWhitespace(int &$length): bool;
 

--- a/src/Builder/LikeConditionBuilder.php
+++ b/src/Builder/LikeConditionBuilder.php
@@ -20,7 +20,7 @@ final class LikeConditionBuilder extends \Yiisoft\Db\QueryBuilder\Condition\Buil
     }
 
     /**
-     * @return string character used to escape special characters in LIKE conditions. By default, it's assumed to be
+     * @return string Character used to escape special characters in LIKE conditions. By default, it's assumed to be
      * `\`.
      */
     private function getEscapeSql(): string

--- a/src/SqlTokenizer.php
+++ b/src/SqlTokenizer.php
@@ -15,7 +15,7 @@ use function strtr;
  * {@see http://www.sqlite.org/draft/tokenreq.html}
  * {@see https://sqlite.org/lang.html}
  */
-final class SqlTokenizer extends BaseTokenizer
+final class SqlTokenizer extends AbstractTokenizer
 {
     /**
      * Returns whether there's a whitespace at the current offset.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
