### PR TITLE
Allow scalar values for `Query::select()`

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -11,7 +11,10 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->paths([
         __DIR__ . '/src',
-        __DIR__ . '/tests',
+        /**
+         * Disabled ./tests directory due to different branches with main package when testing
+         */
+        // __DIR__ . '/tests',
     ]);
 
     // register a single rule

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -773,5 +773,6 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
     /** @dataProvider \Yiisoft\Db\Sqlite\Tests\Provider\QueryBuilderProvider::selectScalar */
     public function testSelectScalar(array|bool|float|int $columns, string $expected): void
     {
+        parent::testSelectScalar($columns, $expected);
     }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -769,4 +769,10 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
             $qb->insert('json_table', ['json_col' => new JsonExpression(['a' => 1, 'b' => 2])]),
         );
     }
+
+    /** @dataProvider \Yiisoft\Db\Sqlite\Tests\Provider\QueryBuilderProvider::selectScalar */
+    public function testSelectScalar(array|bool|float|int $columns, string $expected): void
+    {
+        parent::testSelectScalar($columns, $expected);
+    }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -773,6 +773,5 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
     /** @dataProvider \Yiisoft\Db\Sqlite\Tests\Provider\QueryBuilderProvider::selectScalar */
     public function testSelectScalar(array|bool|float|int $columns, string $expected): void
     {
-        parent::testSelectScalar($columns, $expected);
     }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -771,7 +771,7 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
     }
 
     /** @dataProvider \Yiisoft\Db\Sqlite\Tests\Provider\QueryBuilderProvider::selectScalar */
-    public function testSelectScalar(array|bool|float|int $columns, string $expected): void
+    public function testSelectScalar(array|bool|float|int|string $columns, string $expected): void
     {
         parent::testSelectScalar($columns, $expected);
     }


### PR DESCRIPTION
Update tests according main PR yiisoft/db#816