### PR TITLE
Replace call of `SchemaInterface::getRawTableName()` to `QuoterInterface::getRawTableName()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.0.0 under development
 
 - Enh #289: Implement `SqlParser` and `ExpressionBuilder` driver classes (@Tigrov)
-- Chg #306: Replace call of `SchemaInterface::getRawTableName()` to `QuoterInterface::getRawTableName()` (@Tigrov)
+- Chg #307: Replace call of `SchemaInterface::getRawTableName()` to `QuoterInterface::getRawTableName()` (@Tigrov)
 
 ## 1.2.0 March 21, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0.0 under development
 
 - Enh #289: Implement `SqlParser` and `ExpressionBuilder` driver classes (@Tigrov)
+- Chg #306: Replace call of `SchemaInterface::getRawTableName()` to `QuoterInterface::getRawTableName()` (@Tigrov)
 
 ## 1.2.0 March 21, 2024
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -735,7 +735,7 @@ final class Schema extends AbstractPdoSchema
      */
     protected function getCacheKey(string $name): array
     {
-        return array_merge([self::class], $this->generateCacheKey(), [$this->getRawTableName($name)]);
+        return array_merge([self::class], $this->generateCacheKey(), [$this->db->getQuoter()->getRawTableName($name)]);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | yiisoft/db#767