### PR TITLE
Call `DbArrayHelper::arrange()` instead of `DbArrayHelper::index()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Enh #345: Refactor according changes in `db` package (@Tigrov)
 - New #344: Add `caseSensitive` option to like condition (@vjik)
 - Enh #347: Remove `getCacheKey()` and `getCacheTag()` methods from `Schema` class (@Tigrov)
+- Enh #350: Use `DbArrayHelper::arrange()` instead of `DbArrayHelper::index()` method (@Tigrov)
 
 ## 1.2.0 March 21, 2024
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -158,7 +158,7 @@ final class Schema extends AbstractPdoSchema
 
         $foreignKeysList = $this->getPragmaForeignKeyList($tableName);
         /** @psalm-var GroupedForeignKeyInfo $foreignKeysList */
-        $foreignKeysList = DbArrayHelper::index($foreignKeysList, null, ['table', 'id']);
+        $foreignKeysList = DbArrayHelper::arrange($foreignKeysList, ['table', 'id']);
 
         foreach ($foreignKeysList as $table => $foreignKeysById) {
             /**
@@ -454,10 +454,7 @@ final class Schema extends AbstractPdoSchema
     {
         $tableColumns = $this->getPragmaTableInfo($tableName);
         /** @psalm-var ColumnInfo[] $tableColumns */
-        $tableColumns = array_map(array_change_key_case(...), $tableColumns);
-
-        /** @psalm-var ColumnInfo[] */
-        return DbArrayHelper::index($tableColumns, 'cid');
+        return array_map(array_change_key_case(...), $tableColumns);
     }
 
     /**

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -453,7 +453,7 @@ final class Schema extends AbstractPdoSchema
     private function loadTableColumnsInfo(string $tableName): array
     {
         $tableColumns = $this->getPragmaTableInfo($tableName);
-        /** @psalm-var ColumnInfo[] $tableColumns */
+        /** @psalm-var ColumnInfo[] */
         return array_map(array_change_key_case(...), $tableColumns);
     }
 


### PR DESCRIPTION
Related PR
- https://github.com/yiisoft/db/pull/954

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | 
