### PR TITLE
Rename `getLastInsertID()` method in `ConnectionInterface` to `getLastInsertId()`

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -37,7 +37,7 @@ final class Command extends AbstractPdoCommand
         $result = [];
         foreach ($tablePrimaryKeys as $name) {
             if ($tableSchema?->getColumn($name)?->isAutoIncrement()) {
-                $result[$name] = $this->db->getLastInsertID((string) $tableSchema?->getSequenceName());
+                $result[$name] = $this->db->getLastInsertId((string) $tableSchema?->getSequenceName());
                 continue;
             }
 

--- a/tests/PdoConnectionTest.php
+++ b/tests/PdoConnectionTest.php
@@ -89,7 +89,7 @@ final class PdoConnectionTest extends CommonPdoConnectionTest
             ]
         )->execute();
 
-        $this->assertSame('4', $db->getLastInsertID());
+        $this->assertSame('4', $db->getLastInsertId());
 
         $db->close();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

Related to https://github.com/yiisoft/db/pull/965
