### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       open-pull-requests-limit: 0
 
     # Maintain dependencies for Composer
+      ignore:
+        - dependency-name: "yiisoft/*"
     - package-ecosystem: "composer"
       directory: "/"
       schedule:
@@ -20,3 +22,5 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+      ignore:
+        - dependency-name: "yiisoft/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,8 @@
 version: 2
 updates:
-    # Maintain dependencies for GitHub Actions.
-    - package-ecosystem: "github-actions"
-      directory: "/"
-      schedule:
-          interval: "daily"
-      # Too noisy. See https://github.community/t/increase-if-necessary-for-github-actions-in-dependabot/179581
-      open-pull-requests-limit: 0
-
-    # Maintain dependencies for Composer
-    - package-ecosystem: "composer"
-      directory: "/"
-      schedule:
-          interval: "daily"
-      versioning-strategy: increase-if-necessary
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,18 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"\n    directory: "/"\n    schedule:\n      interval: "weekly"\n    cooldown:\n      default-days: 7\n    ignore:\n      - dependency-name: "yiisoft/*"\n    # Maintain dependencies for GitHub Actions.
-    - package-ecosystem: "github-actions"
-      directory: "/"
-      schedule:
-          interval: "daily"
-      # Too noisy. See https://github.community/t/increase-if-necessary-for-github-actions-in-dependabot/179581
-      open-pull-requests-limit: 0
+  # Maintain dependencies for GitHub Actions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "yiisoft/*"
 
-    # Maintain dependencies for Composer
-    - package-ecosystem: "composer"
-      directory: "/"
-      schedule:
-          interval: "daily"
-      versioning-strategy: increase-if-necessary
+  # Maintain dependencies for Composer
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+        interval: "daily"
+    versioning-strategy: increase-if-necessary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       open-pull-requests-limit: 0
 
     # Maintain dependencies for Composer
-      ignore:
-        - dependency-name: "yiisoft/*"
     - package-ecosystem: "composer"
       directory: "/"
       schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       open-pull-requests-limit: 0
 
     # Maintain dependencies for Composer
+      ignore:
+        - dependency-name: "yiisoft/*"
     - package-ecosystem: "composer"
       directory: "/"
       schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-    # Maintain dependencies for GitHub Actions.
+  - package-ecosystem: "github-actions"\n    directory: "/"\n    schedule:\n      interval: "weekly"\n    cooldown:\n      default-days: 7\n    ignore:\n      - dependency-name: "yiisoft/*"\n    # Maintain dependencies for GitHub Actions.
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
@@ -9,18 +9,8 @@ updates:
       open-pull-requests-limit: 0
 
     # Maintain dependencies for Composer
-      ignore:
-        - dependency-name: "yiisoft/*"
     - package-ecosystem: "composer"
       directory: "/"
       schedule:
           interval: "daily"
       versioning-strategy: increase-if-necessary
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-      ignore:
-        - dependency-name: "yiisoft/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,19 @@
 version: 2
 updates:
+    # Maintain dependencies for GitHub Actions.
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "daily"
+      # Too noisy. See https://github.community/t/increase-if-necessary-for-github-actions-in-dependabot/179581
+      open-pull-requests-limit: 0
+
+    # Maintain dependencies for Composer
+    - package-ecosystem: "composer"
+      directory: "/"
+      schedule:
+          interval: "daily"
+      versioning-strategy: increase-if-necessary
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
     schedule:
         interval: "daily"
     versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 7

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   roave_bc_check:
-    uses: yiisoft/actions/.github/workflows/bc.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/bc.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -13,13 +13,16 @@ on:
 
 name: backwards compatibility
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   roave_bc_check:
-    uses: yiisoft/actions/.github/workflows/bc.yml@master
+    uses: yiisoft/actions/.github/workflows/bc.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,12 +50,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}
@@ -75,8 +75,7 @@ jobs:
         run: vendor/bin/phpunit --coverage-clover=coverage.xml --colors=always --display-warnings --display-deprecations
 
       - name: Upload coverage to Codecov.
-        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ on:
 
 name: build
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -47,10 +50,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}
@@ -61,7 +66,7 @@ jobs:
         run: composer self-update
 
       - name: Install db.
-        uses: yiisoft/actions/install-packages@master
+        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           packages: >-
             ['db']
@@ -70,7 +75,7 @@ jobs:
         run: vendor/bin/phpunit --coverage-clover=coverage.xml --colors=always --display-warnings --display-deprecations
 
       - name: Upload coverage to Codecov.
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         run: composer self-update
 
       - name: Install db.
-        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages@master
         with:
           packages: >-
             ['db']

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   composer-require-checker:
-    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master
     with:
       php: >-
         ['8.1', '8.2', '8.3', '8.4', '8.5']

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -16,13 +16,16 @@ on:
 
 name: Composer require checker
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   composer-require-checker:
-    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master
+    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       php: >-
         ['8.1', '8.2', '8.3', '8.4', '8.5']

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -14,6 +14,9 @@ on:
 
 name: mutation test
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -38,10 +41,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}
@@ -49,10 +54,10 @@ jobs:
           coverage: pcov
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
 
       - name: Install db.
-        uses: yiisoft/actions/install-packages@master
+        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
         with:
           packages: >-
             ['db']

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -41,12 +41,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.EXTENSIONS }}
@@ -54,7 +54,7 @@ jobs:
           coverage: pcov
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
 
       - name: Install db.
         uses: yiisoft/actions/install-packages@master

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -57,7 +57,7 @@ jobs:
         uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f
 
       - name: Install db.
-        uses: yiisoft/actions/install-packages@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+        uses: yiisoft/actions/install-packages@master
         with:
           packages: >-
             ['db']

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -1,7 +1,7 @@
 name: Rector + PHP CS Fixer
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'src/**'
       - 'tests/**'
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   rector:
-    uses: yiisoft/actions/.github/workflows/rector-cs.yml@master
+    uses: yiisoft/actions/.github/workflows/rector-cs.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     secrets:
       token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   rector:
-    uses: yiisoft/actions/.github/workflows/rector-cs.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/rector-cs.yml@master
     with:
       php: '8.1'
       required-packages: >-

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -20,10 +20,7 @@ concurrency:
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector-cs.yml@master
-    secrets:
-      token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:
-      repository: ${{ github.event.pull_request.head.repo.full_name }}
       php: '8.1'
       required-packages: >-
         ['db']

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -20,10 +20,7 @@ concurrency:
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector-cs.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
-    secrets:
-      token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:
-      repository: ${{ github.event.pull_request.head.repo.full_name }}
       php: '8.1'
       required-packages: >-
         ['db']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   psalm:
-    uses: yiisoft/actions/.github/workflows/psalm.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/psalm.yml@master
     with:
       php: >-
         ['8.1', '8.2', '8.3', '8.4']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -16,13 +16,16 @@ on:
 
 name: Static analysis
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   psalm:
-    uses: yiisoft/actions/.github/workflows/psalm.yml@master
+    uses: yiisoft/actions/.github/workflows/psalm.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       php: >-
         ['8.1', '8.2', '8.3', '8.4']

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,8 +14,8 @@ on:
       - '.github/**.yaml'
 
 permissions:
-  actions: read
-  contents: read
+  actions: read # Required by zizmor when reading workflow metadata through the API.
+  contents: read # Required to read workflow files.
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "yiisoft/*": any

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        "yiisoft/*": any


### PR DESCRIPTION
## Summary
- Pin workflow actions to commit SHAs.
- Replace unsafe pull_request_target workflow triggers with pull_request where present.
- Set read-only GITHUB_TOKEN permissions for read-only workflows.
- Disable persisted checkout credentials.

## Validation
- zizmor --no-progress --no-exit-codes db-sqlite/.github/workflows