### PR TITLE
Remove Schema::getSchemaDefaultValues()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SQLite driver for Yii Database Change Log
 
+## 3.0.0 under development
+
+- Chg #1175: Remove `Schema::getSchemaDefaultValues()`, following its removal from
+  `Yiisoft\Db\Constraint\ConstraintSchemaInterface` (@KalimeroMK)
+
 ## 2.0.1 under development
 
 - Bug #413: Fix "GROUP BY" builder ignoring parameters (@vjik)

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -71,14 +71,6 @@ use const PREG_SET_ORDER;
  */
 final class Schema extends AbstractPdoSchema
 {
-    /**
-     * @throws NotSupportedException
-     */
-    public function getSchemaDefaultValues(string $schema = '', bool $refresh = false): array
-    {
-        throw new NotSupportedException(__METHOD__ . ' is not supported by SQLite.');
-    }
-
     protected function findConstraints(TableSchemaInterface $table): void
     {
         $tableName = $this->resolveFullName($table->getName(), $table->getSchemaName());

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -189,16 +189,6 @@ final class SchemaTest extends CommonSchemaTest
         $this->assertContainsOnlyInstancesOf(Check::class, $tableChecks);
     }
 
-    public function testGetSchemaDefaultValues(): void
-    {
-        $db = $this->getSharedConnection();
-
-        $this->expectException(NotSupportedException::class);
-        $this->expectExceptionMessage('Yiisoft\Db\Sqlite\Schema::getSchemaDefaultValues is not supported by SQLite.');
-
-        $db->getSchema()->getSchemaDefaultValues();
-    }
-
     public function testGetSchemaNames(): void
     {
         $db = $this->getSharedConnection();


### PR DESCRIPTION
Follow-up to yiisoft/db#1175, which removes `getSchemaDefaultValues()` from `ConstraintSchemaInterface`. This override existed only to satisfy that declaration by throwing `NotSupportedException`, so it implements nothing once the declaration is gone.

Unlike the other drivers, SQLite does not break without this — the override keeps the call resolvable, so this is cleanup and can merge in any order. `loadTableDefaultValues()` still throws and is covered through `getTableDefaultValues()`.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | yiisoft/db#1175
